### PR TITLE
Update GlyphNote.py

### DIFF
--- a/GlyphNote.glyphsPalette/Contents/Resources/GlyphNote.py
+++ b/GlyphNote.glyphsPalette/Contents/Resources/GlyphNote.py
@@ -128,7 +128,7 @@ class GlyphNote ( NSObject, GlyphsPaletteProtocol ):
 		The minimum height of the view in pixels.
 		"""
 		try:
-			print "__minHeight"
+			# print "__minHeight"
 			return 30
 		except Exception as e:
 			self.logToConsole( "minHeight: %s" % str(e) )
@@ -139,7 +139,7 @@ class GlyphNote ( NSObject, GlyphsPaletteProtocol ):
 		Must be equal to or bigger than minHeight.
 		"""
 		try:
-			print "__maxHeight"
+			# print "__maxHeight"
 			return 150
 		except Exception as e:
 			self.logToConsole( "maxHeight: %s" % str(e) )


### PR DESCRIPTION
Removed these lines

```
print "__minHeight"
print "__maxHeight"
```

It just kept printing these strings in the console?
