### PR TITLE
fix glyph note for layers without paths???

### DIFF
--- a/GlyphNote.glyphsPalette/Contents/Resources/GlyphNote.py
+++ b/GlyphNote.glyphsPalette/Contents/Resources/GlyphNote.py
@@ -220,8 +220,9 @@ class GlyphNote ( NSObject, GlyphsPaletteProtocol ):
 		try:
 			thisGlyph = None
 			windowController = self.currentWindowController(sender)
-			if windowController.activeLayer():
-				thisGlyph = windowController.activeLayer().glyph()
+			layer = windowController.activeLayer()
+			if layer != None:
+				thisGlyph = layer.parent
 			
 			if thisGlyph:
 				# update glyph note in palette:


### PR DESCRIPTION
The if has to check agains None, otherwise it is unreliable. No idea
why.
